### PR TITLE
fix: type 변경에 따른 type 에러 픽스

### DIFF
--- a/src/constants/form-fields.ts
+++ b/src/constants/form-fields.ts
@@ -1,4 +1,6 @@
-export const loginFields = [
+import type { InputField } from '../types/form';
+
+export const loginFields: InputField[] = [
   {
     id: 'email',
     type: 'email',

--- a/src/types/form.ts
+++ b/src/types/form.ts
@@ -1,0 +1,8 @@
+export type InputFieldType = 'text' | 'password' | 'email';
+
+export interface InputField {
+  id: string;
+  type: InputFieldType;
+  label: string;
+  placeholder: string;
+}


### PR DESCRIPTION

## 📘 작업 내역
- Input 컴포넌트의 type props의 type을 변경하면서 발생한 오류 해결
  - string과 'text'|'email'|'password'의 충돌로 인한 타입 오류
  
<br>


## 🔔 추가적인 내용
- 회원가입 먼저 진행 후 계정 확인 기능 추가하기