### PR TITLE
feature: 회원가입 기능 구현

### DIFF
--- a/src/components/checkbox.tsx
+++ b/src/components/checkbox.tsx
@@ -1,0 +1,28 @@
+import type { CheckboxField } from '../types/field';
+
+type CheckboxProps = CheckboxField & {
+  checked: boolean;
+  onChange: (e: React.ChangeEvent<HTMLInputElement>) => void;
+};
+
+const Checkbox = ({ id, name, value, checked, onChange }: CheckboxProps) => {
+  return (
+    <label
+      htmlFor={id}
+      className={`inline-flex items-center py-1 px-3 mt-2 mx-1 rounded-md border cursor-pointer ${checked ? 'outline-1 outline-black' : 'border-gray-300'}`}
+    >
+      <span className='text-center'>{value}</span>
+      <input
+        type='checkbox'
+        id={id}
+        name={name}
+        value={value}
+        onChange={onChange}
+        checked={checked}
+        className='appearance-none absolute'
+      />
+    </label>
+  );
+};
+
+export default Checkbox;

--- a/src/components/input.tsx
+++ b/src/components/input.tsx
@@ -1,10 +1,8 @@
-type InputProps = {
-  label?: string;
-  id: string;
-  type?: 'text' | 'password' | 'email';
+import { useState } from 'react';
+import type { InputField } from '../types/form';
+
+type InputProps = InputField & {
   value: string;
-  placeholder?: string;
-  required?: boolean;
   error?: string;
   touched?: boolean;
   onChange?: (e: React.ChangeEvent<HTMLInputElement>) => void;
@@ -14,16 +12,20 @@ type InputProps = {
 const Input = ({
   label,
   id,
-  type = 'text',
+  type,
   value,
   placeholder,
-  required,
+  helperText,
   error,
   touched,
   onChange,
   onBlur,
+  showToggle = false,
+  rightButtonLabel,
+  rightButtonAction,
 }: InputProps) => {
   const hasError = touched && error;
+  const [visible, setVisible] = useState(false);
 
   return (
     <div className='mb-4'>
@@ -33,21 +35,48 @@ const Input = ({
         </label>
       )}
 
-      <input
-        className={`mt-2 w-full px-4 py-2 border rounded-md focus:outline-none focus:ring-1 ${
-          hasError ? 'border-red-500 focus:ring-red-500' : 'border-gray-300 focus:ring-black'
-        }`}
-        id={id}
-        type={type}
-        name={id}
-        value={value}
-        placeholder={placeholder}
-        required={required}
-        onChange={onChange}
-        onBlur={onBlur}
-      />
+      <div className='w-full relative mt-2'>
+        {/* 헬퍼 텍스트 */}
+        {helperText && <p className='text-xs text-gray-400 mt-2 mb-2'>{helperText}</p>}
 
-      {hasError && <p className='mt-1 text-sm text-red-600'>{error}</p>}
+        {/* input */}
+        <input
+          className={` ${rightButtonLabel ? 'w-[76%]' : 'w-full'} px-4 py-2 border rounded-md focus:outline-none focus:ring-1 ${
+            hasError ? 'border-red-500 focus:ring-red-500' : 'border-gray-300 focus:ring-black'
+          }`}
+          id={id}
+          type={type}
+          name={id}
+          value={value}
+          placeholder={placeholder}
+          onChange={onChange}
+          onBlur={onBlur}
+        />
+
+        {/* 비밀번호 확인 */}
+        {showToggle && type === 'password' && (
+          <button
+            type='button'
+            className='absolute inset-y-0 right-10 px-2 text-sm text-gray-500'
+            onClick={() => setVisible((prev) => !prev)}
+          >
+            {visible ? '숨김' : '표시'}
+          </button>
+        )}
+
+        {/* 버튼 */}
+        {rightButtonLabel && (
+          <button
+            className='absolute right-0 top-1/2 px-3 cursor-pointer h-full rounded-sm text-white text-xs transform -translate-y-1/2 bg-black'
+            onClick={rightButtonAction}
+          >
+            {rightButtonLabel}
+          </button>
+        )}
+      </div>
+
+      {/* 에러 메시지*/}
+      {hasError && <p className='mt-1 text-xs text-red-600'>{error}</p>}
     </div>
   );
 };

--- a/src/components/input.tsx
+++ b/src/components/input.tsx
@@ -23,6 +23,7 @@ const Input = ({
   showToggle = false,
   rightButtonLabel,
   rightButtonAction,
+  inputMode,
 }: InputProps) => {
   const hasError = touched && error;
   const [visible, setVisible] = useState(false);
@@ -51,6 +52,7 @@ const Input = ({
           placeholder={placeholder}
           onChange={onChange}
           onBlur={onBlur}
+          inputMode={inputMode}
         />
 
         {/* 비밀번호 확인 */}

--- a/src/components/input.tsx
+++ b/src/components/input.tsx
@@ -1,8 +1,9 @@
 import { useState } from 'react';
-import type { InputField } from '../types/form';
+import type { SignUpInputField } from '../types/field';
 
-type InputProps = InputField & {
-  value: string;
+type InputProps = SignUpInputField & {
+  id: string;
+  value: string | string[];
   error?: string;
   touched?: boolean;
   onChange?: (e: React.ChangeEvent<HTMLInputElement>) => void;
@@ -78,7 +79,7 @@ const Input = ({
       </div>
 
       {/* 에러 메시지*/}
-      {hasError && <p className='mt-1 text-xs text-red-600'>{error}</p>}
+      {hasError && <p className='mt-2 text-xs text-red-600'>{error}</p>}
     </div>
   );
 };

--- a/src/components/input.tsx
+++ b/src/components/input.tsx
@@ -43,11 +43,11 @@ const Input = ({
 
         {/* input */}
         <input
-          className={` ${rightButtonLabel ? 'w-[76%]' : 'w-full'} px-4 py-2 border rounded-md focus:outline-none focus:ring-1 ${
+          className={` ${rightButtonLabel ? 'w-[76%]' : 'w-full'} px-4 py-2 border rounded-md relative focus:outline-none focus:ring-1 ${
             hasError ? 'border-red-500 focus:ring-red-500' : 'border-gray-300 focus:ring-black'
           }`}
           id={id}
-          type={type}
+          type={visible ? 'text' : type}
           name={id}
           value={value}
           placeholder={placeholder}
@@ -60,7 +60,7 @@ const Input = ({
         {showToggle && type === 'password' && (
           <button
             type='button'
-            className='absolute inset-y-0 right-10 px-2 text-sm text-gray-500'
+            className='absolute bottom-0 right-2 px-2 text-sm text-gray-500 transform -translate-y-1/2 cursor-pointer'
             onClick={() => setVisible((prev) => !prev)}
           >
             {visible ? '숨김' : '표시'}
@@ -71,7 +71,7 @@ const Input = ({
         {rightButtonLabel && (
           <button
             className='absolute right-0 top-1/2 px-3 cursor-pointer h-full rounded-sm text-white text-xs transform -translate-y-1/2 bg-black'
-            onClick={rightButtonAction}
+            onClick={() => rightButtonAction}
           >
             {rightButtonLabel}
           </button>

--- a/src/components/layout/header.tsx
+++ b/src/components/layout/header.tsx
@@ -22,7 +22,7 @@ const Header = () => {
           <div className='w-1/2 hidden min-[480px]:flex min-[480px]:relative'>
             <input
               type='text'
-              className='w-full outline-none placeholder:text-gray-400 placeholder:font-bold placeholder:text-sm border border-gray-400 pl-4 pr-20 py-1.5 rounded-full overflow-hidden focus:ring-1 focus:ring-black'
+              className='w-full placeholder:text-gray-400 placeholder:font-bold placeholder:text-sm border border-gray-400 pl-4 pr-20 py-1.5 rounded-full overflow-hidden focus:outline-1 focus:outline-black'
               placeholder='검색어를 입력하세요'
             />
             <button className='absolute right-0 px-5 h-full cursor-pointer border-l-1 border-gray-400'>

--- a/src/components/radio.tsx
+++ b/src/components/radio.tsx
@@ -1,0 +1,34 @@
+import type { RadioField } from '../types/form';
+
+type RadioProps = RadioField & {
+  checked: boolean;
+  onChange: (e: React.ChangeEvent<HTMLInputElement>) => void;
+};
+
+const Radio = ({ id, name, value, checked, onChange }: RadioProps) => {
+  return (
+    <div
+      className={`w-full flex gap-2 items-center border py-2 px-3 rounded-md  ${checked ? 'outline-1 outline-black' : 'border-gray-300'}`}
+    >
+      <div className='flex items-center justify-center w-[13px] h-[13px] relative'>
+        <input
+          type='radio'
+          id={id}
+          name={name}
+          value={value}
+          onChange={onChange}
+          checked={checked}
+          className='appearance-none w-[13px] h-[13px] border-1 border-gray-800 rounded-full shrink-0 bg-white'
+        />
+        <div
+          className={`absolute w-[7px] h-[7px] rounded-full bg-gray-800 ${checked ? 'opacity-100' : 'opacity-0'}`}
+        />
+      </div>
+      <label htmlFor={id} className='w-full'>
+        {value}
+      </label>
+    </div>
+  );
+};
+
+export default Radio;

--- a/src/components/radio.tsx
+++ b/src/components/radio.tsx
@@ -1,4 +1,4 @@
-import type { RadioField } from '../types/form';
+import type { RadioField } from '../types/field';
 
 type RadioProps = RadioField & {
   checked: boolean;

--- a/src/constants/form-fields.ts
+++ b/src/constants/form-fields.ts
@@ -31,7 +31,6 @@ export const signUpFields: SignUpInputField[] = [
     type: 'email',
     label: '이메일',
     placeholder: '이메일을 입력하세요',
-    rightButtonLabel: '중복 확인',
   },
   {
     id: 'password',

--- a/src/constants/form-fields.ts
+++ b/src/constants/form-fields.ts
@@ -1,12 +1,11 @@
-import type { InputField } from '../types/form';
+import type { InputField, RadioField } from '../types/form';
 
 export const loginInitialValues = { email: '', password: '' };
 export const signUpInitialValues = {
   email: '',
   password: '',
-  passwordConfirm: '',
   birth: '',
-  jobCategory: '',
+  jobCategory: '개발자',
   interests: '',
 };
 
@@ -47,4 +46,12 @@ export const signUpFields: InputField[] = [
     placeholder: '생년월일 8자리를 입력하세요',
     inputMode: 'numeric',
   },
+];
+
+export const jobCategory: RadioField[] = [
+  { name: 'jobCategory', id: 'developer', value: '개발자' },
+  { name: 'jobCategory', id: 'designer', value: '디자이너' },
+  { name: 'jobCategory', id: 'dataAnalyst', value: '데이터 분석가' },
+  { name: 'jobCategory', id: 'PM', value: 'PM' },
+  { name: 'jobCategory', id: 'Marketer', value: '마케터' },
 ];

--- a/src/constants/form-fields.ts
+++ b/src/constants/form-fields.ts
@@ -1,5 +1,15 @@
 import type { InputField } from '../types/form';
 
+export const loginInitialValues = { email: '', password: '' };
+export const signUpInitialValues = {
+  email: '',
+  password: '',
+  passwordConfirm: '',
+  birth: '',
+  jobCategory: '',
+  interests: '',
+};
+
 export const loginFields: InputField[] = [
   {
     id: 'email',
@@ -12,5 +22,28 @@ export const loginFields: InputField[] = [
     type: 'password',
     label: '비밀번호',
     placeholder: '비밀번호를 입력하세요',
+  },
+];
+
+export const signUpFields: InputField[] = [
+  {
+    id: 'email',
+    type: 'email',
+    label: '이메일',
+    placeholder: '이메일을 입력하세요',
+    rightButtonLabel: '중복 확인',
+  },
+  {
+    id: 'password',
+    type: 'password',
+    label: '비밀번호',
+    placeholder: '비밀번호를 입력하세요',
+    helperText: '8자 이상, 영문/숫자/특수기호(!@#$%^&*) 조합',
+  },
+  {
+    id: 'birth',
+    type: 'number',
+    label: '생년월일',
+    placeholder: 'YYYY/MM/DD',
   },
 ];

--- a/src/constants/form-fields.ts
+++ b/src/constants/form-fields.ts
@@ -38,6 +38,7 @@ export const signUpFields: SignUpInputField[] = [
     label: '비밀번호',
     placeholder: '비밀번호를 입력하세요',
     helperText: '8자 이상, 영문/숫자/특수기호(!@#$%^&*) 조합',
+    showToggle: true,
   },
   {
     id: 'birth',

--- a/src/constants/form-fields.ts
+++ b/src/constants/form-fields.ts
@@ -1,15 +1,16 @@
-import type { InputField, RadioField } from '../types/form';
+import type { LoginFormValuesType, SignUpFormValuesType } from '../types/form';
+import type { CheckboxField, LoginInputField, RadioField, SignUpInputField } from '../types/field';
 
-export const loginInitialValues = { email: '', password: '' };
-export const signUpInitialValues = {
+export const loginInitialValues: LoginFormValuesType = { email: '', password: '' };
+export const signUpInitialValues: SignUpFormValuesType = {
   email: '',
   password: '',
   birth: '',
   jobCategory: '개발자',
-  interests: '',
+  interests: [],
 };
 
-export const loginFields: InputField[] = [
+export const loginFields: LoginInputField[] = [
   {
     id: 'email',
     type: 'email',
@@ -24,7 +25,7 @@ export const loginFields: InputField[] = [
   },
 ];
 
-export const signUpFields: InputField[] = [
+export const signUpFields: SignUpInputField[] = [
   {
     id: 'email',
     type: 'email',
@@ -54,4 +55,15 @@ export const jobCategory: RadioField[] = [
   { name: 'jobCategory', id: 'dataAnalyst', value: '데이터 분석가' },
   { name: 'jobCategory', id: 'PM', value: 'PM' },
   { name: 'jobCategory', id: 'Marketer', value: '마케터' },
+];
+
+export const interests: CheckboxField[] = [
+  { name: 'interests', id: 'programming', value: '프로그래밍' },
+  { name: 'interests', id: 'infrastructure', value: '인프라' },
+  { name: 'interests', id: 'planning', value: '기획' },
+  { name: 'interests', id: 'data', value: '데이터' },
+  { name: 'interests', id: 'design', value: '디자인' },
+  { name: 'interests', id: 'business', value: '비즈니스' },
+  { name: 'interests', id: 'marketing', value: '마케팅' },
+  { name: 'interests', id: 'careers/jobChange', value: '취업/이직' },
 ];

--- a/src/constants/form-fields.ts
+++ b/src/constants/form-fields.ts
@@ -42,8 +42,9 @@ export const signUpFields: InputField[] = [
   },
   {
     id: 'birth',
-    type: 'number',
+    type: 'text',
     label: '생년월일',
-    placeholder: 'YYYY/MM/DD',
+    placeholder: '생년월일 8자리를 입력하세요',
+    inputMode: 'numeric',
   },
 ];

--- a/src/hooks/use-form.tsx
+++ b/src/hooks/use-form.tsx
@@ -1,4 +1,5 @@
 import { useEffect, useState } from 'react';
+import { formattedDate } from '../utils/formatted-date';
 
 type UseFormProps = {
   initialValues: Record<string, string>;
@@ -14,7 +15,9 @@ const useForm = ({ initialValues, onSubmit, validate }: UseFormProps) => {
   // 입력 필드 별 값 업데이트
   const handleInputChange = (e: React.ChangeEvent<HTMLInputElement>) => {
     const { name, value } = e.target;
-    setValues((prevValues) => ({ ...prevValues, [name]: value }));
+
+    const formattedValue = name === 'birth' ? formattedDate(value) : value;
+    setValues((prevValues) => ({ ...prevValues, [name]: formattedValue }));
   };
 
   // 입력 필드 별 touched 상태 업데이트 (touched 상태인 입력필드만 검사)

--- a/src/hooks/use-form.tsx
+++ b/src/hooks/use-form.tsx
@@ -11,12 +11,14 @@ function useForm<T>({ initialValues, onSubmit, validate }: UseFormProps<T>) {
   const [values, setValues] = useState<T>(initialValues);
   const [errors, setErrors] = useState<Partial<Record<keyof T, string>>>({});
   const [touched, setTouched] = useState<Partial<Record<keyof T, boolean>>>({});
+  const [isInitialized, setIsInitialized] = useState<boolean>(false);
 
   // 입력 필드 별 값 업데이트
   const handleInputChange = (e: React.ChangeEvent<HTMLInputElement>) => {
     const { name, value } = e.target;
     const formattedValue = name === 'birth' ? formattedDate(value) : value;
     setValues((prevValues) => ({ ...prevValues, [name]: formattedValue }));
+    setIsInitialized(true);
   };
 
   // checkbox용 onChange 함수 (복수선택)
@@ -35,6 +37,7 @@ function useForm<T>({ initialValues, onSubmit, validate }: UseFormProps<T>) {
     });
 
     setTouched((prevTouched) => ({ ...prevTouched, [key]: true }));
+    setIsInitialized(true);
   };
 
   // 입력 필드 별 touched 상태 업데이트 (touched 상태인 입력필드만 검사)
@@ -67,6 +70,7 @@ function useForm<T>({ initialValues, onSubmit, validate }: UseFormProps<T>) {
     handleBlur,
     handleSubmit,
     handleCheckboxChange,
+    isValid: Object.keys(errors).length === 0 && isInitialized,
   };
 }
 

--- a/src/hooks/use-form.tsx
+++ b/src/hooks/use-form.tsx
@@ -1,23 +1,40 @@
 import { useEffect, useState } from 'react';
 import { formattedDate } from '../utils/formatted-date';
 
-type UseFormProps = {
-  initialValues: Record<string, string>;
-  onSubmit: (values: Record<string, string>) => void;
-  validate: (values: Record<string, string>) => Record<string, string | undefined>;
+type UseFormProps<T> = {
+  initialValues: T;
+  onSubmit: (values: T) => void;
+  validate: (values: T) => Partial<Record<keyof T, string>>;
 };
 
-const useForm = ({ initialValues, onSubmit, validate }: UseFormProps) => {
-  const [values, setValues] = useState<Record<string, string>>(initialValues);
-  const [errors, setErrors] = useState<Record<string, string | undefined>>({});
-  const [touched, setTouched] = useState<Record<string, boolean>>({});
+function useForm<T>({ initialValues, onSubmit, validate }: UseFormProps<T>) {
+  const [values, setValues] = useState<T>(initialValues);
+  const [errors, setErrors] = useState<Partial<Record<keyof T, string>>>({});
+  const [touched, setTouched] = useState<Partial<Record<keyof T, boolean>>>({});
 
   // 입력 필드 별 값 업데이트
   const handleInputChange = (e: React.ChangeEvent<HTMLInputElement>) => {
     const { name, value } = e.target;
-
     const formattedValue = name === 'birth' ? formattedDate(value) : value;
     setValues((prevValues) => ({ ...prevValues, [name]: formattedValue }));
+  };
+
+  // checkbox용 onChange 함수 (복수선택)
+  const handleCheckboxChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    const { name, value, checked } = e.target;
+    const key = name as keyof T;
+
+    setValues((prevValues) => {
+      const current = Array.isArray(prevValues[key]) ? prevValues[key] : [];
+
+      if (checked) {
+        return { ...prevValues, [key]: [...current, value] };
+      } else {
+        return { ...prevValues, [key]: current.filter((checkValue) => checkValue !== value) };
+      }
+    });
+
+    setTouched((prevTouched) => ({ ...prevTouched, [key]: true }));
   };
 
   // 입력 필드 별 touched 상태 업데이트 (touched 상태인 입력필드만 검사)
@@ -49,7 +66,8 @@ const useForm = ({ initialValues, onSubmit, validate }: UseFormProps) => {
     handleInputChange,
     handleBlur,
     handleSubmit,
+    handleCheckboxChange,
   };
-};
+}
 
 export default useForm;

--- a/src/pages/login.tsx
+++ b/src/pages/login.tsx
@@ -3,20 +3,20 @@ import { Link } from 'react-router-dom';
 import Input from '../components/input';
 import useForm from '../hooks/use-form';
 import { loginValidator } from '../utils/validators';
-import { loginFields } from '../constants/form-fields';
+import { loginFields, loginInitialValues } from '../constants/form-fields';
+import type { LoginFormValuesType } from '../types/form';
 
 const Login = () => {
-  const initialValues = { email: '', password: '' };
-
   const onSubmit = (values: Record<string, string>) => {
     console.log('로그인 성공', values);
   };
 
-  const { values, touched, errors, handleInputChange, handleBlur, handleSubmit } = useForm({
-    initialValues,
-    onSubmit,
-    validate: loginValidator,
-  });
+  const { values, touched, errors, handleInputChange, handleBlur, handleSubmit } =
+    useForm<LoginFormValuesType>({
+      initialValues: loginInitialValues,
+      onSubmit,
+      validate: loginValidator,
+    });
 
   return (
     <div className='min-h-screen flex flex-col items-center justify-center bg-gray-100'>

--- a/src/pages/signup.tsx
+++ b/src/pages/signup.tsx
@@ -22,7 +22,16 @@ const SignUp = () => {
         <h2 className='text-3xl font-bold text-center text-gray-800 mb-12'>회원가입</h2>
         <form onSubmit={handleSubmit}>
           {signUpFields.map(
-            ({ id, type, label, placeholder, helperText, rightButtonLabel, rightButtonAction }) => {
+            ({
+              id,
+              type,
+              label,
+              placeholder,
+              helperText,
+              rightButtonLabel,
+              rightButtonAction,
+              inputMode,
+            }) => {
               return (
                 <Input
                   key={id}
@@ -38,6 +47,7 @@ const SignUp = () => {
                   rightButtonLabel={rightButtonLabel}
                   rightButtonAction={rightButtonAction}
                   helperText={helperText}
+                  inputMode={inputMode}
                 />
               );
             },

--- a/src/pages/signup.tsx
+++ b/src/pages/signup.tsx
@@ -1,4 +1,4 @@
-import { Link } from 'react-router-dom';
+import { Link, useNavigate } from 'react-router-dom';
 
 import Input from '../components/input';
 import Radio from '../components/radio';
@@ -12,10 +12,28 @@ import {
   signUpInitialValues,
 } from '../constants/form-fields';
 import type { SignUpFormValuesType } from '../types/form';
+import { useAuthStore } from '../stores/use-auth-store';
 
 const SignUp = () => {
+  const nav = useNavigate();
+  const { login } = useAuthStore();
+
   const onSubmit = (values: SignUpFormValuesType) => {
-    console.log('회원가입 성공', values);
+    try {
+      const users = JSON.parse(localStorage.getItem('users') || '[]');
+      const updatedUsers = [...users, values];
+
+      localStorage.setItem('users', JSON.stringify(updatedUsers));
+    } catch {
+      console.error('회원가입 실패');
+    }
+
+    login({
+      email: values.email,
+      password: values.password,
+    });
+
+    nav('/home');
   };
 
   const {

--- a/src/pages/signup.tsx
+++ b/src/pages/signup.tsx
@@ -67,6 +67,7 @@ const SignUp = () => {
               rightButtonLabel,
               rightButtonAction,
               inputMode,
+              showToggle,
             }) => {
               return (
                 <Input
@@ -84,6 +85,7 @@ const SignUp = () => {
                   rightButtonAction={rightButtonAction}
                   helperText={helperText}
                   inputMode={inputMode}
+                  showToggle={showToggle}
                 />
               );
             },

--- a/src/pages/signup.tsx
+++ b/src/pages/signup.tsx
@@ -2,19 +2,34 @@ import { Link } from 'react-router-dom';
 
 import Input from '../components/input';
 import useForm from '../hooks/use-form';
-import { loginValidator } from '../utils/validators';
-import { jobCategory, signUpFields, signUpInitialValues } from '../constants/form-fields';
+import { signUpValidator } from '../utils/validators';
+import {
+  interests,
+  jobCategory,
+  signUpFields,
+  signUpInitialValues,
+} from '../constants/form-fields';
 import Radio from '../components/radio';
+import Checkbox from '../components/checkbox';
+import type { SignUpFormValuesType } from '../types/form';
 
 const SignUp = () => {
-  const onSubmit = (values: Record<string, string>) => {
-    console.log('로그인 성공', values);
+  const onSubmit = (values: SignUpFormValuesType) => {
+    console.log('회원가입 성공', values);
   };
 
-  const { values, touched, errors, handleInputChange, handleBlur, handleSubmit } = useForm({
+  const {
+    values,
+    touched,
+    errors,
+    handleInputChange,
+    handleCheckboxChange,
+    handleBlur,
+    handleSubmit,
+  } = useForm<SignUpFormValuesType>({
     initialValues: signUpInitialValues,
     onSubmit,
-    validate: loginValidator,
+    validate: signUpValidator,
   });
 
   return (
@@ -22,6 +37,7 @@ const SignUp = () => {
       <div className='w-full max-w-md bg-white pt-10 pb-20 px-8 rounded-xl'>
         <h2 className='text-3xl font-bold text-center text-gray-800 mb-12'>회원가입</h2>
         <form onSubmit={handleSubmit}>
+          {/* 이메일, 비밀번호, 생년월일 */}
           {signUpFields.map(
             ({
               id,
@@ -54,6 +70,7 @@ const SignUp = () => {
             },
           )}
 
+          {/* 직군: 단일 선택 */}
           <p className='text-sm'>직군</p>
           <div className='flex flex-col py-2 gap-4'>
             {jobCategory.map(({ name, id, value }) => {
@@ -70,6 +87,27 @@ const SignUp = () => {
             })}
           </div>
 
+          {/* 관심 카테고리: 복수 선택 */}
+          <p className='text-sm pt-4'>관심 카테고리</p>
+          <div className='gap-4'>
+            {interests.map(({ name, id, value }) => {
+              return (
+                <Checkbox
+                  key={id}
+                  id={id}
+                  name={name}
+                  value={value}
+                  checked={values.interests.includes(value)}
+                  onChange={handleCheckboxChange}
+                />
+              );
+            })}
+          </div>
+          {errors['interests'] && touched['interests'] && (
+            <p className='mt-2 text-xs text-red-600'>{errors['interests']}</p>
+          )}
+
+          {/* 회원가입 버튼 */}
           <div className='mt-8'>
             <button
               type='submit'
@@ -80,7 +118,7 @@ const SignUp = () => {
           </div>
         </form>
 
-        {/* 회원가입 버튼 */}
+        {/* 로그인 이동 버튼 */}
         <div className='mt-6 text-center'>
           <p className='text-sm text-gray-600'>
             <span>Playlist 회원이신가요?</span>

--- a/src/pages/signup.tsx
+++ b/src/pages/signup.tsx
@@ -3,7 +3,8 @@ import { Link } from 'react-router-dom';
 import Input from '../components/input';
 import useForm from '../hooks/use-form';
 import { loginValidator } from '../utils/validators';
-import { signUpFields, signUpInitialValues } from '../constants/form-fields';
+import { jobCategory, signUpFields, signUpInitialValues } from '../constants/form-fields';
+import Radio from '../components/radio';
 
 const SignUp = () => {
   const onSubmit = (values: Record<string, string>) => {
@@ -52,6 +53,23 @@ const SignUp = () => {
               );
             },
           )}
+
+          <p className='text-sm'>직군</p>
+          <div className='flex flex-col py-2 gap-4'>
+            {jobCategory.map(({ name, id, value }) => {
+              return (
+                <Radio
+                  key={id}
+                  id={id}
+                  name={name}
+                  value={value}
+                  checked={values.jobCategory === value}
+                  onChange={handleInputChange}
+                />
+              );
+            })}
+          </div>
+
           <div className='mt-8'>
             <button
               type='submit'

--- a/src/pages/signup.tsx
+++ b/src/pages/signup.tsx
@@ -1,5 +1,69 @@
+import { Link } from 'react-router-dom';
+
+import Input from '../components/input';
+import useForm from '../hooks/use-form';
+import { loginValidator } from '../utils/validators';
+import { signUpFields, signUpInitialValues } from '../constants/form-fields';
+
 const SignUp = () => {
-  return <div>SignUp</div>;
+  const onSubmit = (values: Record<string, string>) => {
+    console.log('로그인 성공', values);
+  };
+
+  const { values, touched, errors, handleInputChange, handleBlur, handleSubmit } = useForm({
+    initialValues: signUpInitialValues,
+    onSubmit,
+    validate: loginValidator,
+  });
+
+  return (
+    <div className='min-h-screen flex flex-col items-center justify-center bg-gray-100'>
+      <div className='w-full max-w-md bg-white pt-10 pb-20 px-8 rounded-xl'>
+        <h2 className='text-3xl font-bold text-center text-gray-800 mb-12'>회원가입</h2>
+        <form onSubmit={handleSubmit}>
+          {signUpFields.map(
+            ({ id, type, label, placeholder, helperText, rightButtonLabel, rightButtonAction }) => {
+              return (
+                <Input
+                  key={id}
+                  id={id}
+                  type={type}
+                  label={label}
+                  placeholder={placeholder}
+                  value={values[id]}
+                  onChange={handleInputChange}
+                  onBlur={handleBlur}
+                  error={errors[id]}
+                  touched={touched[id]}
+                  rightButtonLabel={rightButtonLabel}
+                  rightButtonAction={rightButtonAction}
+                  helperText={helperText}
+                />
+              );
+            },
+          )}
+          <div className='mt-8'>
+            <button
+              type='submit'
+              className='w-full py-2 bg-black text-white rounded-full cursor-pointer hover:bg-gray-800 transition'
+            >
+              회원가입
+            </button>
+          </div>
+        </form>
+
+        {/* 회원가입 버튼 */}
+        <div className='mt-6 text-center'>
+          <p className='text-sm text-gray-600'>
+            <span>Playlist 회원이신가요?</span>
+            <Link to='/signup' className='text-black font-semibold hover:underline ml-1'>
+              로그인
+            </Link>
+          </p>
+        </div>
+      </div>
+    </div>
+  );
 };
 
 export default SignUp;

--- a/src/pages/signup.tsx
+++ b/src/pages/signup.tsx
@@ -1,6 +1,8 @@
 import { Link } from 'react-router-dom';
 
 import Input from '../components/input';
+import Radio from '../components/radio';
+import Checkbox from '../components/checkbox';
 import useForm from '../hooks/use-form';
 import { signUpValidator } from '../utils/validators';
 import {
@@ -9,8 +11,6 @@ import {
   signUpFields,
   signUpInitialValues,
 } from '../constants/form-fields';
-import Radio from '../components/radio';
-import Checkbox from '../components/checkbox';
 import type { SignUpFormValuesType } from '../types/form';
 
 const SignUp = () => {
@@ -22,6 +22,7 @@ const SignUp = () => {
     values,
     touched,
     errors,
+    isValid,
     handleInputChange,
     handleCheckboxChange,
     handleBlur,
@@ -111,7 +112,8 @@ const SignUp = () => {
           <div className='mt-8'>
             <button
               type='submit'
-              className='w-full py-2 bg-black text-white rounded-full cursor-pointer hover:bg-gray-800 transition'
+              className='w-full py-2 bg-black text-white rounded-full cursor-pointer hover:bg-gray-800 transition disabled:bg-gray-400 disabled:cursor-default'
+              disabled={!isValid}
             >
               회원가입
             </button>

--- a/src/stores/use-auth-store.tsx
+++ b/src/stores/use-auth-store.tsx
@@ -1,0 +1,66 @@
+import { create } from 'zustand';
+import type { LoginFormValuesType, SignUpFormValuesType } from '../types/form';
+import { persist } from 'zustand/middleware';
+
+type User = {
+  email: string;
+  birth: string;
+  jobCategory: string;
+  interests: string[];
+};
+
+type AuthStore = {
+  user: User | null;
+  isLoggedIn: boolean;
+  login: ({ email, password }: LoginFormValuesType) => boolean;
+  logout: () => void;
+};
+
+export const useAuthStore = create<AuthStore>()(
+  persist(
+    (set, get) => ({
+      user: null,
+      isLoggedIn: false,
+
+      login: ({ email, password }: LoginFormValuesType) => {
+        const users: SignUpFormValuesType[] = JSON.parse(localStorage.getItem('users') || '[]');
+        const matched = users.find((user) => user.email === email && user.password === password);
+
+        if (matched) {
+          set({
+            user: {
+              email: matched.email,
+              birth: matched.birth,
+              jobCategory: matched.jobCategory,
+              interests: matched.interests,
+            },
+            isLoggedIn: true,
+          });
+          return true;
+        }
+        return false;
+      },
+
+      logout: () => set({ user: null, isLoggedIn: false }),
+
+      updateUser: (updated: User) => {
+        const state = get();
+        if (!state.user) return;
+
+        const updateUser = { ...state.user, ...updated };
+        const users: SignUpFormValuesType[] = JSON.parse(localStorage.getItem('users') || '[]');
+
+        const updatedUsers = users.map((user: User) =>
+          user.email === state.user?.email ? { ...user, ...updated } : user,
+        );
+
+        localStorage.setItem('users', JSON.stringify(updatedUsers));
+        set({ user: updateUser });
+      },
+    }),
+    {
+      name: 'auth-store',
+      partialize: (state) => ({ user: state.user, isLoggedIn: state.isLoggedIn }),
+    },
+  ),
+);

--- a/src/types/field.ts
+++ b/src/types/field.ts
@@ -1,0 +1,35 @@
+// 필드 타입
+import type { LoginFormValuesType, SignUpFormValuesType } from './form';
+
+export type InputFieldType = 'text' | 'password' | 'email' | 'number';
+
+type CommonInputField = {
+  type: InputFieldType;
+  label?: string;
+  placeholder?: string;
+};
+
+export type LoginInputField = CommonInputField & {
+  id: keyof LoginFormValuesType;
+};
+
+export type SignUpInputField = CommonInputField & {
+  id: keyof SignUpFormValuesType;
+  helperText?: string;
+  showToggle?: boolean;
+  rightButtonLabel?: string;
+  rightButtonAction?: () => void;
+  inputMode?: React.HTMLAttributes<HTMLInputElement>['inputMode'];
+};
+
+export type RadioField = {
+  id: string;
+  name: string;
+  value: string;
+};
+
+export type CheckboxField = {
+  id: string;
+  name: string;
+  value: string;
+};

--- a/src/types/form.ts
+++ b/src/types/form.ts
@@ -9,4 +9,11 @@ export type InputField = {
   showToggle?: boolean;
   rightButtonLabel?: string;
   rightButtonAction?: () => void;
+  inputMode?: 'numeric' | 'decimal' | 'tel' | 'search' | 'url' | 'email';
+};
+
+export type RadioField = {
+  name: string;
+  id: string;
+  value: string;
 };

--- a/src/types/form.ts
+++ b/src/types/form.ts
@@ -1,8 +1,12 @@
-export type InputFieldType = 'text' | 'password' | 'email';
+export type InputFieldType = 'text' | 'password' | 'email' | 'number';
 
-export interface InputField {
+export type InputField = {
   id: string;
   type: InputFieldType;
-  label: string;
-  placeholder: string;
-}
+  label?: string;
+  placeholder?: string;
+  helperText?: string;
+  showToggle?: boolean;
+  rightButtonLabel?: string;
+  rightButtonAction?: () => void;
+};

--- a/src/types/form.ts
+++ b/src/types/form.ts
@@ -1,19 +1,10 @@
-export type InputFieldType = 'text' | 'password' | 'email' | 'number';
-
-export type InputField = {
-  id: string;
-  type: InputFieldType;
-  label?: string;
-  placeholder?: string;
-  helperText?: string;
-  showToggle?: boolean;
-  rightButtonLabel?: string;
-  rightButtonAction?: () => void;
-  inputMode?: 'numeric' | 'decimal' | 'tel' | 'search' | 'url' | 'email';
+export type LoginFormValuesType = {
+  email: string;
+  password: string;
 };
 
-export type RadioField = {
-  name: string;
-  id: string;
-  value: string;
+export type SignUpFormValuesType = LoginFormValuesType & {
+  birth: string;
+  jobCategory: string;
+  interests: string[];
 };

--- a/src/utils/formatted-date.ts
+++ b/src/utils/formatted-date.ts
@@ -1,0 +1,7 @@
+export function formattedDate(value: string) {
+  const digit = value.replace(/\D/g, '');
+
+  if (digit.length <= 4) return digit;
+  if (digit.length <= 6) return `${digit.slice(0, 4)}-${digit.slice(4)}`;
+  return `${digit.slice(0, 4)}-${digit.slice(4, 6)}-${digit.slice(6, 8)}`;
+}

--- a/src/utils/validators.ts
+++ b/src/utils/validators.ts
@@ -11,9 +11,32 @@ function validatePassword(value: string): string | undefined {
   const passwordRegex = /^(?=.*[a-zA-Z])(?=.*[0-9])(?=.*[!@#$%^&*])[a-zA-Z0-9!@#$%^&*]{8,}$/;
   if (!value.length) return '비밀번호를 입력하세요.';
   if (!passwordRegex.test(value))
-    return '비밀번호를 확인해주세요. (최소 8자, 영문,숫자,특수문자 1개 이상 포함)';
+    return '비밀번호를 확인해주세요. (최소 8자, 영문,숫자,특수문자 포함)';
 
   return undefined;
+}
+
+function validateBirth(value: string): string | undefined {
+  const birthRegex = /^[0-9]{4}-[0-9]{2}-[0-9]{2}$/;
+
+  if (!value.length) return '생년월일을 입력하세요.';
+  if (birthRegex.test(value)) return '입력하신 생년월일 형식이 올바르지 않습니다.';
+
+  const date = new Date(value);
+  const [year, month, day] = value.split('-').map(Number);
+
+  // 날짜 생성 후, Date 객체를 통해 진짜 유효한 날짜인지 검사
+  // ex: 2023-02-30 -> 2023-03-02가 되어 두 값이 달라짐. 즉, 없는 날짜
+  const isValidDate =
+    date.getFullYear() === year && date.getMonth() + 1 === month && date.getDate() === day;
+
+  // 현재 년도 기준으로 유효성 검사
+  const thisYear = new Date().getFullYear();
+  const isValidYear = year >= thisYear - 100 && year <= thisYear;
+
+  if (!isValidDate || !isValidYear) {
+    return '입력하신 생년월일이 유효하지 않습니다.';
+  }
 }
 
 export function loginValidator(values: Record<string, string>): Record<string, string | undefined> {
@@ -24,6 +47,23 @@ export function loginValidator(values: Record<string, string>): Record<string, s
 
   const pwError = validatePassword(values.password);
   if (pwError) errors.password = pwError;
+
+  return errors;
+}
+
+export function signUpValidator(
+  values: Record<string, string>,
+): Record<string, string | undefined> {
+  const errors: Record<string, string | undefined> = {};
+
+  const emailError = validateEmail(values.email);
+  if (emailError) errors.email = emailError;
+
+  const pwError = validatePassword(values.password);
+  if (pwError) errors.password = pwError;
+
+  const birthError = validateBirth(values.birth);
+  if (birthError) errors.birth = birthError;
 
   return errors;
 }

--- a/src/utils/validators.ts
+++ b/src/utils/validators.ts
@@ -1,14 +1,17 @@
 // 유효성 검사 함수
 
+import type { LoginFormValuesType, SignUpFormValuesType } from '../types/form';
+
 function validateEmail(value: string): string | undefined {
   const emailRegex = /^[a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+\.[a-zA-Z]{2,4}$/;
   if (!value.length) return '이메일을 입력하세요.';
   if (!emailRegex.test(value)) return '이메일 주소가 유효하지 않습니다.';
+
   return undefined;
 }
 
 function validatePassword(value: string): string | undefined {
-  const passwordRegex = /^(?=.*[a-zA-Z])(?=.*[0-9])(?=.*[!@#$%^&*])[a-zA-Z0-9!@#$%^&*]{8,}$/;
+  const passwordRegex = /^(?=.*[a-zA-Z])(?=.*[0-9])(?=.*[!@#$%^&*])[a-zA-Z0-9!@#$%^&*]{8,20}$/;
   if (!value.length) return '비밀번호를 입력하세요.';
   if (!passwordRegex.test(value))
     return '비밀번호를 확인해주세요. (최소 8자, 영문,숫자,특수문자 포함)';
@@ -20,7 +23,7 @@ function validateBirth(value: string): string | undefined {
   const birthRegex = /^[0-9]{4}-[0-9]{2}-[0-9]{2}$/;
 
   if (!value.length) return '생년월일을 입력하세요.';
-  if (birthRegex.test(value)) return '입력하신 생년월일 형식이 올바르지 않습니다.';
+  if (!birthRegex.test(value)) return '입력하신 생년월일 형식이 올바르지 않습니다.';
 
   const date = new Date(value);
   const [year, month, day] = value.split('-').map(Number);
@@ -37,10 +40,19 @@ function validateBirth(value: string): string | undefined {
   if (!isValidDate || !isValidYear) {
     return '입력하신 생년월일이 유효하지 않습니다.';
   }
+
+  return undefined;
 }
 
-export function loginValidator(values: Record<string, string>): Record<string, string | undefined> {
-  const errors: Record<string, string | undefined> = {};
+function validateInterests(value: string[]): string | undefined {
+  if (!value.length) return '관심사를 한 가지 이상 선택해주세요.';
+  return undefined;
+}
+
+export function loginValidator(
+  values: LoginFormValuesType,
+): Partial<Record<keyof LoginFormValuesType, string>> {
+  const errors: Partial<Record<keyof LoginFormValuesType, string>> = {};
 
   const emailError = validateEmail(values.email);
   if (emailError) errors.email = emailError;
@@ -52,9 +64,9 @@ export function loginValidator(values: Record<string, string>): Record<string, s
 }
 
 export function signUpValidator(
-  values: Record<string, string>,
-): Record<string, string | undefined> {
-  const errors: Record<string, string | undefined> = {};
+  values: SignUpFormValuesType,
+): Partial<Record<keyof SignUpFormValuesType, string>> {
+  const errors: Partial<Record<keyof SignUpFormValuesType, string>> = {};
 
   const emailError = validateEmail(values.email);
   if (emailError) errors.email = emailError;
@@ -64,6 +76,9 @@ export function signUpValidator(
 
   const birthError = validateBirth(values.birth);
   if (birthError) errors.birth = birthError;
+
+  const interestsError = validateInterests(values.interests);
+  if (interestsError) errors.interests = interestsError;
 
   return errors;
 }


### PR DESCRIPTION
## 📘 작업 내역
- input 기능 확장
  - 버튼 추가
  - 비밀번호 보임/숨김 토글 추가
  - 헬퍼 텍스트 추가
- radio / checkbox를 사용하여 단일/복수 선택 구현
- 유효성 검사 통과 시 회원가입 버튼 활성화
- zustand를 사용하여 현재 유저 정보 관리
- 회원가입 기능 구현
- 비밀번호 확인 버튼 오류 해결
  - type 미지정 및 props 미추가로 인한 오류 

<br>

## 🔔 추가적인 내용
### 다음 작업
- 회원 정보 수정 및 로그아웃 기능 구현
- 유저 권한
  - 로그인 한 유저는 login, signup 경로에 들어갈 수 없게 막기
  - 로그인 한 유저는 로그인 버튼 대신 사용자 관련 메뉴가 뜨게 변경하기
  - 로그인 한 유저만 회원 정보 수정 

### 개선하면 좋을 부분

- 로그인/회원가입 에러 처리
   - 로그인: 이메일 혹은 비밀번호가 다릅니다. 에러 메시지 출력
   - 회원가입: 이미 가입된 계정입니다. 에러 메시지 출력 및 유효성 검증 실패 처리


> Input 내부에 있는 rightButtonAction의 실행 결과 값을 validators에 어떻게 전달해야 하는가? 에서 막혀버렸다.
> validators에서 함수를 직접 실행하는 게 가장 빠르긴 한데, 버튼 없이 중복 확인을 진행 하는 게 
> 사용자 입장에서 조금 낯설지 않은가? 생각이 들었다.
> 
> 지금 생각 나는 건 zustand 정도...? 그런데 이렇게 하다보면 상태 관리를 여러 곳에서 하게 되니 조금 고민 해봐야 될 것 같다.
